### PR TITLE
add event type specific queries, change time filter to account for month and day

### DIFF
--- a/event_data/constants.js
+++ b/event_data/constants.js
@@ -13,4 +13,22 @@ const months = {
     12: 'December',
 };
 
-module.exports = { months };
+// Easier to just cache this since it's very inefficient to generate from the dataset
+const adventureIslands = [
+    "Medeia",
+    "Opportunity Isle",
+    "Tranquil Isle",
+    "Oblivion Isle",
+    "Asura Island",
+    "Drumbeat Island",
+    "Forpe",
+    "Snowpang Island",
+    "Phantomwing Island",
+    "Volare Island",
+    "Lagoon Island",
+    "Lush Reed Island",
+    "Monte Island",
+    "Harmony Island"
+]
+
+module.exports = { months, adventureIslands };

--- a/event_data/eventData.js
+++ b/event_data/eventData.js
@@ -9,8 +9,8 @@ const merchantSchedules = require("./data/merchantSchedules.json");
 
 const eventData = require('./data/data.json');
 const eventNames = require('./data/events.json');
-const eventTypes = require('./data/msgs.json');
-const { months } = require('./constants.js');
+const eventTypes = require('./data/msgs.json')[0];
+const { months, adventureIslands } = require('./constants.js');
 
 const util = require('util');
 
@@ -54,6 +54,50 @@ function getEventName(id) {
     return eventNames[id][0];
 }
 
+function getAllEventNamesOfType(eventType_, log = false){
+    // provide a string name of the event type, e.g. "Adventure Island"
+
+    let outputNames;
+    if (eventType_ == "Adventure Island"){
+        // Easier to just cache this since it's very inefficient to generate from the dataset
+        outputNames = adventureIslands;
+    } else {
+        let eventIds = new Set();
+    
+        Object.entries(eventData).forEach((eventType) => {
+            const [type, monthDayMap] = eventType;
+            if (eventTypes[type][0] != eventType_){
+                return; // continue the loop
+            }
+            for (const [month, days] of Object.entries(monthDayMap)) {
+                for (const [day, events] of Object.entries(days)) {
+                    for (const [iLvl, event] of Object.entries(events)) {
+                        for (const [eventId, eventTimes] of Object.entries(event)) {
+                            eventIds.add(eventId);
+                        }
+                    }
+                }
+            }
+        });
+        
+        outputNames = [];
+        eventIds.forEach((eventId) => {
+            outputNames.push(eventNames[eventId][0]);
+        })
+    }
+
+
+    if (log) {
+        console.log(`Retrieved all event names of type ${eventType_}:`);
+        outputNames.forEach((eventName) => {
+            console.log(eventName);
+        });
+    }
+    
+    // Returns an array of string names
+    return outputNames;
+}
+
 function getAllEvents(log = false) {
     let outputEvents = [];
 
@@ -76,6 +120,40 @@ function getAllEvents(log = false) {
 
     if (log) {
         console.log('Retrieved all events:');
+        outputEvents.forEach((event) => {
+            console.log(event);
+        });
+    }
+
+    return outputEvents;
+}
+
+function getAllEventsOfType(eventType_, log = false){
+    // provide a string name of the event type, e.g. "Adventure Island"
+    let outputEvents = [];
+
+    Object.entries(eventData).forEach((eventType) => {
+        const [type, monthDayMap] = eventType;
+        if (eventTypes[type][0] != eventType_){
+            return; // continue the loop
+        }
+        for (const [month, days] of Object.entries(monthDayMap)) {
+            for (const [day, events] of Object.entries(days)) {
+                for (const [iLvl, event] of Object.entries(events)) {
+                    for (const [eventId, eventTimes] of Object.entries(event)) {
+                        eventTimes.forEach((individualTime) => {
+                            outputEvents.push(
+                                new LAEvent(eventId, month, day, individualTime)
+                            );
+                        });
+                    }
+                }
+            }
+        }
+    });
+
+    if (log) {
+        console.log(`Retrieved all events of type ${eventType_}:`);
         outputEvents.forEach((event) => {
             console.log(event);
         });
@@ -156,19 +234,21 @@ function getAllEventsOnDate(month_, day_, log = false) {
     }
 }
 
-function filterEventsAfterTime(eventCollection, time, log = false) {
-    // use a four digit military time without the colon
+function filterEventsAfterTime(eventCollection, datetime, log = false) {
+    // datetime format should be a string of format MMDDTTTT, where TTTT is military time without the colon
     let outputEvents = eventCollection.filter((lAEvent) => {
+        const startMonth = lAEvent.month;
+        const startDay = lAEvent.day;
         const startHour = lAEvent.time.slice(0, 2);
         const startMinute = lAEvent.time.slice(3, 5);
-        return time <= Number(startHour) * 100 + Number(startMinute);
+        return Number(datetime) <= startMonth * 1000000 + startDay * 10000 + Number(startHour) * 100 + Number(startMinute);
     });
 
     if (log) {
         console.log(
-            `Filtered events occuring on or after ${time
+            `Filtered events occuring on or after ${months[Number(datetime.slice(0, 2))]} ${Number(datetime.slice(2, 4))} at ${datetime
                 .toString()
-                .slice(0, 2)}:${time.toString().slice(2, 4)}`
+                .slice(4, 6)}:${datetime.toString().slice(6, 8)}`
         );
         outputEvents.forEach((event) => {
             console.log(event);
@@ -210,12 +290,15 @@ function sortEventsByTime(eventCollection, log = false) {
     return null; // return null as a reminder that this sorts in place and modifies the original array
 }
 
+
 module.exports = {
     logAll,
+    getAllEventNamesOfType,
     getAllEvents,
     getAllEventsWithId,
     getAllEventsWithName,
     getAllEventsOnDate,
+    getAllEventsOfType,
     filterEventsAfterTime,
     sortEventsByTime,
 };

--- a/event_data/tests.js
+++ b/event_data/tests.js
@@ -2,10 +2,12 @@
 
 const {
     logAll,
+    getAllEventNamesOfType,
     getAllEvents,
     getAllEventsWithId,
     getAllEventsWithName,
     getAllEventsOnDate,
+    getAllEventsOfType,
     filterEventsAfterTime,
     sortEventsByTime,
 } = require('./eventData.js');
@@ -15,6 +17,10 @@ const {
 // getAllEventsWithName("Proving Grounds Deathmatch", true);
 // getAllEventsOnDate(4, 18, true);
 
-let collection = getAllEventsWithId(4005, true);
-collection = filterEventsAfterTime(collection, 1500, true);
-sortEventsByTime(collection, true);
+// let collection =       getAllEventsWithId(4005, true);
+// collection =        filterEventsAfterTime(collection, "04171500", true);
+// sortEventsByTime(collection, true);
+
+getAllEventNamesOfType("Adventure Island", true);
+let islandTimes = getAllEventsOfType("Adventure Island", true);
+islandTimes = filterEventsAfterTime(islandTimes, "04191500", true);


### PR DESCRIPTION
Added functions for event type specific queries:

```
getAllEventNamesOfType("Adventure Island");
```
can be used to return a list of all adventure island names.

```
getAllEventsOfType("Adventure Island");
```
can be used to return a collection of all adventure island events


Also modified `filterEventsAfterTime` to take an 8 digit datetime in the MMDDTTTT format, so we can filter out events occurring after a specific date and time. Note that we currently don't have any way to distinguish the year of the event, as well as account for changes in daylight savings (neither exists in the event data). We will need to implement that at some point.