### PR TITLE
Ratelimit individual hotfix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ DEV_README.md
 # Config files
 config.ts
 prisma/dev.db
+prisma/dev.db-journal
 
 # Log files
 *.log


### PR DESCRIPTION
Ratelimit originally was just using a generic heartgram "unique" id. Obviously it wasn't very unique. Now attached user Discord ID to make each ratelimit actually unique.